### PR TITLE
Fix npm run start command

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2,4 +2,9 @@ import { NestFactory } from '@nestjs/core';
 import { ApplicationModule } from './modules/app.module';
 
 const app = NestFactory.create(ApplicationModule);
-app.listen(3000, () => console.log('Application is listening on port 3000'));
+
+app.then((instance) => (
+  instance.listen(3000, () => console.log('Listening on port 3000'))
+)).catch((err) => {
+  console.log('err', err);
+})


### PR DESCRIPTION
Related to https://github.com/kamilmysliwiec/nest-typescript-starter/issues/7, but also happened with the babel starter kit